### PR TITLE
fix: Add threshold tuning and VQC device bridging

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -126,7 +126,7 @@ def _run_fold_tabnet(
 
     wrapper = TabNetWrapper(cfg=cfg.tabnet, training_cfg=cfg.training_tabnet)
     wrapper.fit(fold.X_train, fold.y_train, fold.X_val, fold.y_val)
-    result = wrapper.predict(fold.X_test)
+    result = wrapper.predict(fold.X_test, X_val=fold.X_val, y_val=fold.y_val)
 
     return compute_metrics(
         model_name="tabnet",

--- a/src/models/classical/tabnet_model.py
+++ b/src/models/classical/tabnet_model.py
@@ -17,6 +17,7 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
+import torch
 from pytorch_tabnet.tab_model import TabNetClassifier
 
 from src.config import TabNetConfig, TrainingConfigTabNet
@@ -59,7 +60,7 @@ class TabNetWrapper:
             n_steps=self.cfg.n_steps,
             gamma=self.cfg.gamma,
             lambda_sparse=self.cfg.lambda_sparse,
-            optimizer_fn=None,  # Uses default Adam
+            optimizer_fn=torch.optim.Adam,
             verbose=0,
             seed=42,
         )
@@ -79,21 +80,34 @@ class TabNetWrapper:
             batch_size=self.training_cfg.batch_size,
         )
 
-    def predict(self, X: np.ndarray) -> TabNetResult:
-        """Generate predictions and probabilities."""
+    def predict(
+        self,
+        X: np.ndarray,
+        X_val: np.ndarray | None = None,
+        y_val: np.ndarray | None = None,
+    ) -> TabNetResult:
+        """Generate predictions with optional threshold tuning on validation set."""
         if self.model is None:
             raise RuntimeError("TabNet not fitted yet. Call fit() first.")
 
-        y_prob = self.model.predict_proba(X)
-        y_pred = self.model.predict(X)
+        y_prob = self.model.predict_proba(X)[:, 1]
 
-        # Count parameters
+        # Threshold tuning on real-distribution validation set
+        threshold = 0.5
+        if X_val is not None and y_val is not None:
+            from src.training.trainer import find_optimal_threshold
+            val_prob = self.model.predict_proba(X_val)[:, 1]
+            threshold = find_optimal_threshold(y_val, val_prob)
+            logger.info("TabNet tuned threshold: %.4f", threshold)
+
+        y_pred = (y_prob >= threshold).astype(int)
+
         total_params = sum(
             p.numel() for p in self.model.network.parameters() if p.requires_grad
         )
 
         return TabNetResult(
             y_pred=y_pred,
-            y_prob=y_prob[:, 1],
+            y_prob=y_prob,
             param_count={"classical": total_params, "quantum": 0, "total": total_params},
         )

--- a/src/models/quantum/parallel.py
+++ b/src/models/quantum/parallel.py
@@ -83,12 +83,14 @@ class ParallelHybrid(nn.Module):
         self.post_fc = nn.Sequential(*post_layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        device = x.device
+
         # Classical branch
         mlp_out = self.mlp_branch(x)           # (batch, mlp_out_dim)
 
-        # Quantum branch
-        vqc_in = self.vqc_proj(x)              # (batch, n_qubits)
-        vqc_out = self.vqc(vqc_in).unsqueeze(-1)  # (batch, 1)
+        # Quantum branch (VQC runs on CPU via PennyLane)
+        vqc_in = self.vqc_proj(x).cpu()        # (batch, n_qubits)
+        vqc_out = self.vqc(vqc_in).unsqueeze(-1).to(device)  # (batch, 1)
 
         # Concatenate and classify
         combined = torch.cat([mlp_out, vqc_out], dim=-1)  # (batch, mlp+1)

--- a/src/models/quantum/shnn.py
+++ b/src/models/quantum/shnn.py
@@ -76,8 +76,11 @@ class SHNN(nn.Module):
         self.post_fc = nn.Sequential(*post_layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        device = x.device
         x = self.pre_fc(x)             # (batch, n_qubits)
+        x = x.cpu()                    # VQC runs on CPU (PennyLane)
         x = self.vqc(x).unsqueeze(-1)  # (batch, 1)
+        x = x.to(device)              # Back to original device
         x = self.post_fc(x)            # (batch, 1)
         return x
 

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -144,6 +144,12 @@ def train_pytorch_model(
         train_losses.append(avg_loss)
 
         # ── Validate ──────────────────────────────────────────────────
+        # Use fixed 0.5 threshold for early stopping signal. Although the
+        # val set has real class distribution (0.17% fraud), the slowly-
+        # climbing MCC at 0.5 provides a stable monotonic proxy for
+        # representation quality. Threshold tuning happens *after* training
+        # for final test predictions — tuning it per-epoch causes premature
+        # early stopping because val_mcc peaks too early.
         model.eval()
         with torch.no_grad():
             val_prob = model(X_val_t).cpu().numpy().flatten()


### PR DESCRIPTION
Closes #3

## Summary

- Add threshold tuning on validation set to TabNet `predict()` — MCC improved from 0.250 to 0.456
- Bridge CPU↔device in SHNN and ParallelHybrid forward passes so PennyLane VQC (always CPU) works with MPS/CUDA
- Fix `optimizer_fn=None` crash in TabNet for newer pytorch-tabnet versions

## Test plan

- [x] `pixi run test` — all 21 tests pass
- [x] Classical baseline re-run confirmed: SNN 0.544±0.019, TabNet 0.456±0.064
- [x] SHNN fold 1 completed without device error (MCC 0.506, ~5h)