### PR TITLE
chore: Disable early stopping for full-epoch benchmark runs

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -73,13 +73,13 @@ training:
   batch_size: 256
   lr: 0.001
   weight_decay: 0.00001
-  early_stopping_patience: 10
+  early_stopping_patience: 9999
   optimizer: adam
   device: auto
 
 training_tabnet:
   max_epochs: 100
-  patience: 10
+  patience: 9999
   batch_size: 256
 
 # ── Evaluation ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #5

## Summary

- Set `early_stopping_patience` and `patience` to 9999 in `configs/default.yaml`
- Quantum models (SHNN, Parallel) were stopping at epoch 5-15 out of 100 — far too early
- Best checkpoint is always restored at end of training, so this can only improve results

## Test plan

- [x] `pixi run test` — all 21 tests pass
- [x] Full benchmark restarted and confirmed running (`tail /tmp/benchmark_all.log`)