### PR TITLE
fix: correct VQC angle encoding range and quantum learning rate

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -92,6 +92,15 @@ training:
   optimizer: adam
   device: auto
 
+training_quantum:
+  epochs: 100
+  batch_size: 256
+  lr: 0.01
+  weight_decay: 0.00001
+  early_stopping_patience: 9999
+  optimizer: adam
+  device: auto
+
 training_tabnet:
   max_epochs: 100
   patience: 9999

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -103,7 +103,7 @@ def _run_fold_pytorch(
         X_val=fold.X_val,
         y_val=fold.y_val,
         X_test=fold.X_test,
-        cfg=cfg.training,
+        cfg=cfg.training_quantum if model_name in ("shnn", "parallel") else cfg.training,
         checkpoint_path=checkpoint_path,
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -158,6 +158,7 @@ class BenchmarkConfig(BaseModel):
     resnet: ResNetConfig = ResNetConfig()
 
     training: TrainingConfig = TrainingConfig()
+    training_quantum: TrainingConfig = TrainingConfig(lr=0.01)
     training_tabnet: TrainingConfigTabNet = TrainingConfigTabNet()
     evaluation: EvaluationConfig = EvaluationConfig()
     paths: PathsConfig = PathsConfig()

--- a/src/models/quantum/parallel.py
+++ b/src/models/quantum/parallel.py
@@ -14,11 +14,19 @@ classical representation learning and quantum-enhanced feature mapping.
 
 from __future__ import annotations
 
+import math
+
 import torch
 from torch import nn
 
 from src.config import NoiseConfig, ParallelHybridConfig
 from src.models.quantum.vqc import build_vqc_layer
+
+
+class _PiSigmoid(nn.Module):
+    """Maps any real input to (0, π): x → π · sigmoid(x)."""
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return math.pi * torch.sigmoid(x)
 
 
 class ParallelHybrid(nn.Module):
@@ -59,10 +67,11 @@ class ParallelHybrid(nn.Module):
         mlp_out_dim = cfg.mlp_dims[-1] if cfg.mlp_dims else input_dim
 
         # ── Quantum VQC branch ───────────────────────────────────────────
-        # Project input to qubit dimension, then pass through VQC
+        # Project input to qubit dimension, then scale to (0, π) for AngleEmbedding.
+        # π*sigmoid maps any real value to (0, π) — the correct encoding range.
         self.vqc_proj = nn.Sequential(
             nn.Linear(input_dim, n_qubits),
-            nn.Tanh(),  # Bound for angle encoding
+            _PiSigmoid(),
         )
         self.vqc = build_vqc_layer(cfg.vqc, noise_cfg)
         vqc_out_dim = 1  # Single expectation value

--- a/src/models/quantum/shnn.py
+++ b/src/models/quantum/shnn.py
@@ -12,11 +12,19 @@ high-dimensional feature transformer in the quantum-enhanced Hilbert space.
 
 from __future__ import annotations
 
+import math
+
 import torch
 from torch import nn
 
 from src.config import NoiseConfig, SHNNConfig
 from src.models.quantum.vqc import build_vqc_layer
+
+
+class _PiSigmoid(nn.Module):
+    """Maps any real input to (0, π): x → π · sigmoid(x)."""
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return math.pi * torch.sigmoid(x)
 
 
 class SHNN(nn.Module):
@@ -53,9 +61,11 @@ class SHNN(nn.Module):
                 nn.Dropout(cfg.dropout),
             ])
             in_dim = out_dim
-        # Project to qubit dimension
+        # Project to qubit dimension, then scale to (0, π) for AngleEmbedding.
+        # Tanh → [-1,+1] only covers ±57° of rotation — wrong range.
+        # π*sigmoid maps any real value to (0, π), matching the expected encoding range.
         pre_layers.append(nn.Linear(in_dim, n_qubits))
-        pre_layers.append(nn.Tanh())  # Bound inputs for angle encoding
+        pre_layers.append(_PiSigmoid())
         self.pre_fc = nn.Sequential(*pre_layers)
 
         # ── VQC layer ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #23

## Summary
- Replace \`nn.Tanh()\` with \`π·sigmoid()\` in SHNN and Parallel: VQC inputs now in \`(0, π)\` instead of \`(-1, +1)\`
- Add \`training_quantum\` config block with \`lr=0.01\` (10× higher than classical), matching the prior standalone VQC benchmark

## Test plan
- [x] SHNN VQC input range: [1.18, 2.01], Parallel: [0.77, 2.40] — both within (0, π)
- [x] \`cfg.training_quantum.lr == 0.01\`, \`cfg.training.lr == 0.001\`