### PR TITLE
docs: hyperlink MIT license in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ The VQC provides 100% of the model's predictive signal. Without it, SHNN collaps
 
 ## License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
Trivial fix — link the MIT text in the license section to the LICENSE file.