### PR TITLE
docs: remove F1-Fraud and ROC-AUC from evaluation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ Input (8) ──┬─→ MLP [16, 8] ──────────────
 |---|---|
 | **MCC** | Primary — balanced, threshold-aware, robust to imbalance |
 | **PR-AUC** | Primary — threshold-free, captures precision/recall trade-off |
-| F1-Fraud | Secondary reference |
-| ROC-AUC | Secondary reference |
 
 Early stopping: patience 20 (quantum) / 15 (classical), monitored on validation MCC.
 Final threshold: tuned on validation set post-training using `find_optimal_threshold`.


### PR DESCRIPTION
The exposé (section 3.4) specifies only MCC and PR-AUC as evaluation metrics. F1-Fraud and ROC-AUC were not mentioned and should not appear in the README's evaluation framework.