### PR TITLE
feat: add 10-qubit ablation config

### DIFF
--- a/configs/ablation_10qubits.yaml
+++ b/configs/ablation_10qubits.yaml
@@ -1,0 +1,61 @@
+# Ablation: 10-qubit SHNN
+# Overrides default.yaml with 10 PCA components / 10 qubits.
+# n_qubits is auto-synced to n_components by the model validator.
+# Compare fold 0 result against 8-qubit baseline (MCC=0.6382, 122 params).
+#
+# Expected params: Linear(10→10) + Linear(1→1) + VQC(3×10×2) = 112 + 60 = 172 total
+
+seed: 42
+models_to_run: [shnn]
+
+data:
+  raw_path: data/raw/creditcard.csv
+  target_column: Class
+  drop_columns: [Time]
+  test_size: 0.20
+  random_state: 42
+
+preprocessing:
+  n_components: 10
+  robust_scale: true
+  minmax_range: [0.0, 3.14159265]
+
+smote:
+  enabled: true
+  k_neighbors: 5
+  random_state: 42
+
+cv:
+  n_folds: 5
+  shuffle: true
+  random_state: 42
+
+noise:
+  enabled: false
+  backend: default.mixed
+  depolarizing_p: 0.0
+
+shnn:
+  pre_fc_dims: []
+  post_fc_dims: []
+  dropout: 0.1
+  vqc:
+    n_layers: 2
+    backend: lightning.qubit
+    diff_method: adjoint
+
+training_quantum:
+  epochs: 100
+  batch_size: 256
+  lr: 0.01
+  weight_decay: 0.00001
+  early_stopping_patience: 20
+  optimizer: adam
+  device: auto
+
+paths:
+  results_dir: results
+  figures_dir: results/figures
+  metrics_dir: results/metrics
+  models_dir: results/models
+  folds_dir: results/folds


### PR DESCRIPTION
Closes #60

## Summary
- Add `configs/ablation_10qubits.yaml` — overrides n_components to 10, n_qubits auto-syncs via model validator
- Expected params: ~172 total (112 classical + 60 quantum) vs 8-qubit baseline 122 params

## Test plan
- [x] Config loads correctly: n_components=10, n_qubits=10, n_layers=2
- [ ] Fold 0 result compared against 8-qubit MCC=0.6382