### PR TITLE
ci: add GitHub Actions workflow to run test suite on every PR (#94)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          cache: true
+
+      - run: pixi run test


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` — runs `pixi run test` (39 tests) on every push to main and every PR
- Uses `prefix-dev/setup-pixi@v0.8.1` with lock-file caching for fast installs
- `linux-64` already in `pyproject.toml` platforms so the committed `pixi.lock` has Linux entries

## Test plan
- [ ] CI job appears and passes on this PR

Closes #94