### PR TITLE
docs: add reproducing figures quickstart to README (#96)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ All hyperparameters are in `configs/default.yaml`. Pass `--config path/to/custom
 
 ---
 
+## Reproducing Figures
+
+Fold results are committed, so all benchmark figures can be regenerated without re-running the benchmark (~185 h).
+
+```bash
+# 12 benchmark figures — no dataset needed, reads committed results/folds/*.json
+pixi run plots
+
+# 6 conceptual figures — requires creditcard.csv in data/raw/
+pixi run python scripts/run_conceptual_figures.py
+
+# Wilcoxon signed-rank statistics — no dataset needed
+pixi run python scripts/run_statistics.py
+```
+
+All output goes to `results/figures/`.
+
+---
+
 ## Preprocessing Pipeline
 
 | Challenge | Solution |


### PR DESCRIPTION
## Summary
- Adds a "Reproducing Figures" section to README after the Running section
- Explains that `pixi run plots` regenerates all 12 benchmark figures with no dataset (fold results committed)
- Notes which scripts need `creditcard.csv` and which don't

## Test plan
- [ ] Section renders correctly on GitHub
- [ ] CI passes

Closes #96