### PR TITLE
ci: add coverage reporting and badge via Codecov (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,9 @@ jobs:
         with:
           cache: true
 
-      - run: pixi run test
+      - run: pixi run pytest tests/ -v --cov=src --cov-report=xml
+
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # HQNN Fraud Detection Benchmark
 
+[![CI](https://github.com/g8rdier/hqnn-fraud-detection-benchmark/actions/workflows/ci.yml/badge.svg)](https://github.com/g8rdier/hqnn-fraud-detection-benchmark/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/g8rdier/hqnn-fraud-detection-benchmark/branch/main/graph/badge.svg)](https://codecov.io/gh/g8rdier/hqnn-fraud-detection-benchmark)
+
 ## Academic Context
 
 | | |


### PR DESCRIPTION
## Summary
- Extends CI to generate `coverage.xml` and upload to Codecov (free for public repos)
- Adds CI status badge and Codecov badge to README header

## Test plan
- [ ] CI job passes on this PR
- [ ] Codecov badge resolves after first upload

Closes #98