### PR TITLE
ci: add Codecov token to coverage upload step (#100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
 
       - run: pixi run pytest tests/ -v --cov=src --cov-report=xml
 
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Upgrades codecov-action v4 → v5
- Passes CODECOV_TOKEN secret so the badge resolves

## Test plan
- [ ] CI passes and Codecov badge shows a percentage

Closes #100