### PR TITLE
docs: Fix degree name to Bachelor of Science Business Informatics

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 | | |
 |---|---|
-| **Degree** | Bachelor of Science in Artificial Intelligence |
+| **Degree** | Bachelor of Science Business Informatics |
 | **Institution** | IU International University of Applied Sciences, Munich |
 | **Supervisor** | Prof. Dr. rer. nat. Michael Barth |
 | **Student** | Gregor Kobilarov |


### PR DESCRIPTION
Closes #108

## Summary
- Corrects degree name in the Academic Context table from "Bachelor of Science in Artificial Intelligence" to "Bachelor of Science Business Informatics"