### PR TITLE
feat(plots): add PHNN architecture diagram (#130)

### DIFF
--- a/results/figures/phnn_architecture.svg
+++ b/results/figures/phnn_architecture.svg
@@ -1,0 +1,2359 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1072.8pt" height="316.745156pt" viewBox="0 0 1072.8 316.745156" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-06-20T14:32:32.997050</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.10.8, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 316.745156 
+L 1072.8 316.745156 
+L 1072.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="line2d_1">
+    <path d="M 108.260129 167.025156 
+L 115.088516 167.025156 
+" clip-path="url(#pf4e1ab6c4f)" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_2">
+    <path d="M 115.088516 229.733956 
+L 115.088516 104.316356 
+" clip-path="url(#pf4e1ab6c4f)" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_2">
+    <path d="M 117.085186 104.316356 
+Q 124.98601 104.316356 131.209782 104.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 127.209782 102.316356 
+L 131.209782 104.316356 
+L 127.209782 106.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 229.754907 104.316356 
+Q 239.36307 104.316356 247.294182 104.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 243.294182 102.316356 
+L 247.294182 104.316356 
+L 243.294182 106.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 345.836737 104.316356 
+Q 360.567194 104.316356 373.620599 104.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 369.620599 102.316356 
+L 373.620599 104.316356 
+L 369.620599 106.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 492.64906 104.316356 
+Q 503.965037 104.316356 513.603963 104.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 509.603963 102.316356 
+L 513.603963 104.316356 
+L 509.603963 106.316356 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 117.08752 229.733956 
+Q 143.768787 229.733956 168.773003 229.733956 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 164.773003 227.733956 
+L 168.773003 229.733956 
+L 164.773003 231.733956 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 267.310869 229.733956 
+Q 287.16372 229.733956 305.339519 229.733956 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 301.339519 227.733956 
+L 305.339519 229.733956 
+L 301.339519 231.733956 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_3">
+    <path d="M 610.146581 104.316356 
+L 625.169032 104.316356 
+" clip-path="url(#pf4e1ab6c4f)" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_4">
+    <path d="M 401.880774 229.733956 
+L 625.169032 229.733956 
+" clip-path="url(#pf4e1ab6c4f)" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="line2d_5">
+    <path d="M 625.169032 229.733956 
+L 625.169032 104.316356 
+" clip-path="url(#pf4e1ab6c4f)" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 627.165535 167.025156 
+Q 629.264172 167.025156 629.685759 167.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 625.685759 165.025156 
+L 629.685759 167.025156 
+L 625.685759 169.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 728.230666 167.025156 
+Q 729.301075 167.025156 728.694434 167.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 724.694434 165.025156 
+L 728.694434 167.025156 
+L 724.694434 169.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 827.239444 167.025156 
+Q 831.726281 167.025156 834.536066 167.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 830.536066 165.025156 
+L 834.536066 167.025156 
+L 830.536066 169.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 933.079444 167.025156 
+Q 937.566281 167.025156 940.376066 167.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 936.376066 165.025156 
+L 940.376066 167.025156 
+L 936.376066 169.025156 
+" style="fill: none; stroke: #636e72; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 17.442581 229.733956 
+L 106.211613 229.733956 
+Q 108.942968 229.733956 108.942968 218.332356 
+L 108.942968 115.717956 
+Q 108.942968 104.316356 106.211613 104.316356 
+L 17.442581 104.316356 
+Q 14.711226 104.316356 14.711226 115.717956 
+L 14.711226 218.332356 
+Q 14.711226 229.733956 17.442581 229.733956 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 136.939355 167.025156 
+L 225.708387 167.025156 
+Q 228.439742 167.025156 228.439742 155.623556 
+L 228.439742 53.009156 
+Q 228.439742 41.607556 225.708387 41.607556 
+L 136.939355 41.607556 
+Q 134.208 41.607556 134.208 53.009156 
+L 134.208 155.623556 
+Q 134.208 167.025156 136.939355 167.025156 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 253.021935 167.025156 
+L 341.790968 167.025156 
+Q 344.522323 167.025156 344.522323 155.623556 
+L 344.522323 53.009156 
+Q 344.522323 41.607556 341.790968 41.607556 
+L 253.021935 41.607556 
+Q 250.290581 41.607556 250.290581 53.009156 
+L 250.290581 155.623556 
+Q 250.290581 167.025156 253.021935 167.025156 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 379.347097 167.025156 
+L 488.60129 167.025156 
+Q 491.332645 167.025156 491.332645 155.623556 
+L 491.332645 53.009156 
+Q 491.332645 41.607556 488.60129 41.607556 
+L 379.347097 41.607556 
+Q 376.615742 41.607556 376.615742 53.009156 
+L 376.615742 155.623556 
+Q 376.615742 167.025156 379.347097 167.025156 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #d8ccf5; stroke: #6c5ce7; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 519.329032 167.025156 
+L 608.098065 167.025156 
+Q 610.829419 167.025156 610.829419 155.623556 
+L 610.829419 53.009156 
+Q 610.829419 41.607556 608.098065 41.607556 
+L 519.329032 41.607556 
+Q 516.597677 41.607556 516.597677 53.009156 
+L 516.597677 155.623556 
+Q 516.597677 167.025156 519.329032 167.025156 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #d8ccf5; stroke: #6c5ce7; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 174.495484 292.442756 
+L 263.264516 292.442756 
+Q 265.995871 292.442756 265.995871 281.041156 
+L 265.995871 178.426756 
+Q 265.995871 167.025156 263.264516 167.025156 
+L 174.495484 167.025156 
+Q 171.764129 167.025156 171.764129 178.426756 
+L 171.764129 281.041156 
+Q 171.764129 292.442756 174.495484 292.442756 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 311.063226 292.442756 
+L 399.832258 292.442756 
+Q 402.563613 292.442756 402.563613 281.041156 
+L 402.563613 178.426756 
+Q 402.563613 167.025156 399.832258 167.025156 
+L 311.063226 167.025156 
+Q 308.331871 167.025156 308.331871 178.426756 
+L 308.331871 281.041156 
+Q 308.331871 292.442756 311.063226 292.442756 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 635.411613 229.733956 
+L 724.180645 229.733956 
+Q 726.912 229.733956 726.912 218.332356 
+L 726.912 115.717956 
+Q 726.912 104.316356 724.180645 104.316356 
+L 635.411613 104.316356 
+Q 632.680258 104.316356 632.680258 115.717956 
+L 632.680258 218.332356 
+Q 632.680258 229.733956 635.411613 229.733956 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 734.423226 229.733956 
+L 823.192258 229.733956 
+Q 825.923613 229.733956 825.923613 218.332356 
+L 825.923613 115.717956 
+Q 825.923613 104.316356 823.192258 104.316356 
+L 734.423226 104.316356 
+Q 731.691871 104.316356 731.691871 115.717956 
+L 731.691871 218.332356 
+Q 731.691871 229.733956 734.423226 229.733956 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 840.263226 229.733956 
+L 929.032258 229.733956 
+Q 931.763613 229.733956 931.763613 218.332356 
+L 931.763613 115.717956 
+Q 931.763613 104.316356 929.032258 104.316356 
+L 840.263226 104.316356 
+Q 837.531871 104.316356 837.531871 115.717956 
+L 837.531871 218.332356 
+Q 837.531871 229.733956 840.263226 229.733956 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 946.103226 229.733956 
+L 1034.872258 229.733956 
+Q 1037.603613 229.733956 1037.603613 218.332356 
+L 1037.603613 115.717956 
+Q 1037.603613 104.316356 1034.872258 104.316356 
+L 946.103226 104.316356 
+Q 943.371871 104.316356 943.371871 115.717956 
+L 943.371871 218.332356 
+Q 943.371871 229.733956 946.103226 229.733956 
+z
+" clip-path="url(#pf4e1ab6c4f)" style="fill: #dfe6e9; stroke: #000000; stroke-width: 1.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 379.612177 184.127556 
+Q 493.723961 184.127556 607.835745 184.127556 
+" style="fill: none; stroke: #0984e3; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 383.612177 186.127556 
+L 379.612177 184.127556 
+L 383.612177 182.127556 
+" style="fill: none; stroke: #0984e3; stroke-width: 1.5; stroke-linecap: round"/>
+    <path d="M 603.835745 182.127556 
+L 607.835745 184.127556 
+L 603.835745 186.127556 
+" style="fill: none; stroke: #0984e3; stroke-width: 1.5; stroke-linecap: round"/>
+   </g>
+   <g id="text_1">
+    <!-- Quantum module (PennyLane · lightning.qubit) -->
+    <g style="fill: #0984e3" transform="translate(405.606135 204.080356) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-ItalicMT-51" d="M 3869 369 
+Q 4100 94 4494 -163 
+L 4222 -525 
+Q 3806 -253 3475 134 
+Q 3009 -84 2588 -84 
+Q 2250 -84 1847 44 
+Q 1444 172 1172 431 
+Q 900 691 745 1098 
+Q 591 1506 591 2000 
+Q 591 2597 819 3144 
+Q 1009 3594 1314 3920 
+Q 1619 4247 1981 4425 
+Q 2459 4659 3016 4659 
+Q 3872 4659 4411 4101 
+Q 4950 3544 4950 2606 
+Q 4950 1916 4662 1333 
+Q 4375 750 3869 369 
+z
+M 3494 763 
+Q 3872 1056 4106 1570 
+Q 4341 2084 4341 2641 
+Q 4341 3334 3959 3742 
+Q 3578 4150 3025 4150 
+Q 2563 4150 2134 3879 
+Q 1706 3609 1450 3087 
+Q 1194 2566 1194 1950 
+Q 1194 1178 1675 756 
+Q 2050 428 2478 428 
+Q 2819 428 3091 534 
+Q 2806 794 2506 950 
+L 2728 1331 
+Q 2931 1244 3095 1123 
+Q 3259 1003 3494 763 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-75" d="M 2478 600 
+Q 1881 -75 1256 -75 
+Q 872 -75 636 145 
+Q 400 366 400 684 
+Q 400 894 506 1403 
+L 906 3319 
+L 1472 3319 
+L 1028 1197 
+Q 972 931 972 784 
+Q 972 597 1086 492 
+Q 1200 388 1422 388 
+Q 1659 388 1886 503 
+Q 2113 619 2277 816 
+Q 2441 1013 2544 1281 
+Q 2613 1453 2703 1884 
+L 3003 3319 
+L 3569 3319 
+L 2875 0 
+L 2353 0 
+L 2478 600 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-61" d="M 2450 413 
+Q 2156 159 1884 42 
+Q 1613 -75 1303 -75 
+Q 844 -75 562 195 
+Q 281 466 281 888 
+Q 281 1166 407 1380 
+Q 534 1594 743 1723 
+Q 953 1853 1256 1909 
+Q 1447 1947 1980 1969 
+Q 2513 1991 2744 2081 
+Q 2809 2313 2809 2466 
+Q 2809 2663 2666 2775 
+Q 2469 2931 2091 2931 
+Q 1734 2931 1507 2773 
+Q 1281 2616 1178 2325 
+L 606 2375 
+Q 781 2869 1161 3131 
+Q 1541 3394 2119 3394 
+Q 2734 3394 3094 3100 
+Q 3369 2881 3369 2531 
+Q 3369 2266 3291 1916 
+L 3106 1091 
+Q 3019 697 3019 450 
+Q 3019 294 3088 0 
+L 2516 0 
+Q 2469 163 2450 413 
+z
+M 2659 1681 
+Q 2541 1634 2405 1609 
+Q 2269 1584 1950 1556 
+Q 1456 1513 1253 1445 
+Q 1050 1378 947 1231 
+Q 844 1084 844 906 
+Q 844 669 1008 516 
+Q 1172 363 1475 363 
+Q 1756 363 2015 511 
+Q 2275 659 2425 925 
+Q 2575 1191 2659 1681 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-6e" d="M 213 0 
+L 906 3319 
+L 1419 3319 
+L 1297 2741 
+Q 1631 3081 1922 3237 
+Q 2213 3394 2516 3394 
+Q 2919 3394 3148 3175 
+Q 3378 2956 3378 2591 
+Q 3378 2406 3297 2009 
+L 2875 0 
+L 2309 0 
+L 2750 2103 
+Q 2816 2409 2816 2556 
+Q 2816 2722 2702 2825 
+Q 2588 2928 2372 2928 
+Q 1938 2928 1598 2615 
+Q 1259 2303 1100 1544 
+L 778 0 
+L 213 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-74" d="M 1534 459 
+L 1441 -3 
+Q 1238 -56 1047 -56 
+Q 709 -56 509 109 
+Q 359 234 359 450 
+Q 359 559 441 953 
+L 844 2881 
+L 397 2881 
+L 488 3319 
+L 934 3319 
+L 1106 4134 
+L 1753 4525 
+L 1500 3319 
+L 2056 3319 
+L 1963 2881 
+L 1409 2881 
+L 1025 1047 
+Q 953 697 953 628 
+Q 953 528 1011 475 
+Q 1069 422 1200 422 
+Q 1388 422 1534 459 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-6d" d="M 209 0 
+L 903 3319 
+L 1469 3319 
+L 1353 2772 
+Q 1669 3125 1917 3259 
+Q 2166 3394 2456 3394 
+Q 2766 3394 2973 3230 
+Q 3181 3066 3247 2772 
+Q 3500 3084 3779 3239 
+Q 4059 3394 4369 3394 
+Q 4784 3394 4992 3197 
+Q 5200 3000 5200 2644 
+Q 5200 2491 5128 2138 
+L 4681 0 
+L 4116 0 
+L 4572 2194 
+Q 4631 2463 4631 2578 
+Q 4631 2741 4528 2834 
+Q 4425 2928 4238 2928 
+Q 3984 2928 3721 2775 
+Q 3459 2622 3314 2373 
+Q 3169 2125 3059 1609 
+L 2722 0 
+L 2156 0 
+L 2625 2241 
+Q 2675 2469 2675 2566 
+Q 2675 2728 2573 2828 
+Q 2472 2928 2309 2928 
+Q 2069 2928 1805 2775 
+Q 1541 2622 1375 2348 
+Q 1209 2075 1103 1569 
+L 775 0 
+L 209 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-20" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-6f" d="M 313 1259 
+Q 313 2231 884 2869 
+Q 1356 3394 2122 3394 
+Q 2722 3394 3089 3019 
+Q 3456 2644 3456 2006 
+Q 3456 1434 3225 942 
+Q 2994 450 2567 187 
+Q 2141 -75 1669 -75 
+Q 1281 -75 964 90 
+Q 647 256 480 559 
+Q 313 863 313 1259 
+z
+M 878 1316 
+Q 878 847 1103 605 
+Q 1328 363 1675 363 
+Q 1856 363 2034 436 
+Q 2213 509 2366 659 
+Q 2519 809 2626 1001 
+Q 2734 1194 2800 1416 
+Q 2897 1725 2897 2009 
+Q 2897 2459 2670 2707 
+Q 2444 2956 2100 2956 
+Q 1834 2956 1615 2829 
+Q 1397 2703 1220 2459 
+Q 1044 2216 961 1892 
+Q 878 1569 878 1316 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-64" d="M 2450 481 
+Q 1966 -75 1438 -75 
+Q 966 -75 652 273 
+Q 338 622 338 1284 
+Q 338 1891 586 2392 
+Q 834 2894 1207 3144 
+Q 1581 3394 1956 3394 
+Q 2575 3394 2891 2797 
+L 3266 4581 
+L 3828 4581 
+L 2872 0 
+L 2350 0 
+L 2450 481 
+z
+M 900 1391 
+Q 900 1044 969 844 
+Q 1038 644 1203 511 
+Q 1369 378 1600 378 
+Q 1984 378 2297 778 
+Q 2716 1309 2716 2091 
+Q 2716 2484 2509 2706 
+Q 2303 2928 1991 2928 
+Q 1788 2928 1620 2837 
+Q 1453 2747 1289 2530 
+Q 1125 2313 1012 1978 
+Q 900 1644 900 1391 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-6c" d="M 169 0 
+L 1125 4581 
+L 1691 4581 
+L 734 0 
+L 169 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-65" d="M 2650 1128 
+L 3200 1072 
+Q 3081 663 2654 294 
+Q 2228 -75 1638 -75 
+Q 1269 -75 961 95 
+Q 653 266 492 591 
+Q 331 916 331 1331 
+Q 331 1875 582 2386 
+Q 834 2897 1234 3145 
+Q 1634 3394 2100 3394 
+Q 2694 3394 3048 3025 
+Q 3403 2656 3403 2019 
+Q 3403 1775 3359 1519 
+L 916 1519 
+Q 903 1422 903 1344 
+Q 903 878 1117 633 
+Q 1331 388 1641 388 
+Q 1931 388 2212 578 
+Q 2494 769 2650 1128 
+z
+M 1006 1950 
+L 2869 1950 
+Q 2872 2038 2872 2075 
+Q 2872 2500 2659 2726 
+Q 2447 2953 2113 2953 
+Q 1750 2953 1451 2703 
+Q 1153 2453 1006 1950 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-28" d="M 1031 -1347 
+Q 541 -272 541 863 
+Q 541 1619 739 2270 
+Q 938 2922 1344 3559 
+Q 1613 3984 2203 4659 
+L 2644 4659 
+Q 2278 4269 1870 3559 
+Q 1463 2850 1278 2165 
+Q 1094 1481 1094 791 
+Q 1094 -241 1453 -1347 
+L 1031 -1347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-50" d="M 275 0 
+L 1234 4581 
+L 3147 4581 
+Q 3644 4581 3892 4467 
+Q 4141 4353 4303 4076 
+Q 4466 3800 4466 3456 
+Q 4466 3172 4350 2878 
+Q 4234 2584 4057 2393 
+Q 3881 2203 3700 2106 
+Q 3519 2009 3313 1963 
+Q 2872 1859 2422 1859 
+L 1275 1859 
+L 888 0 
+L 275 0 
+z
+M 1384 2378 
+L 2394 2378 
+Q 2981 2378 3256 2504 
+Q 3531 2631 3697 2890 
+Q 3863 3150 3863 3441 
+Q 3863 3666 3775 3808 
+Q 3688 3950 3528 4017 
+Q 3369 4084 2916 4084 
+L 1741 4084 
+L 1384 2378 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-79" d="M 0 -1281 
+L 34 -750 
+Q 209 -800 375 -800 
+Q 547 -800 653 -722 
+Q 791 -619 953 -334 
+L 1134 -9 
+L 581 3319 
+L 1138 3319 
+L 1388 1641 
+Q 1463 1144 1516 647 
+L 3000 3319 
+L 3591 3319 
+L 1475 -441 
+Q 1169 -991 931 -1169 
+Q 694 -1347 384 -1347 
+Q 188 -1347 0 -1281 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-4c" d="M 256 0 
+L 1213 4581 
+L 1825 4581 
+L 978 519 
+L 3356 519 
+L 3247 0 
+L 256 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-b7" d="M 969 1969 
+L 1103 2609 
+L 1744 2609 
+L 1606 1969 
+L 969 1969 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-69" d="M 1016 3941 
+L 1150 4581 
+L 1713 4581 
+L 1578 3941 
+L 1016 3941 
+z
+M 191 0 
+L 884 3319 
+L 1450 3319 
+L 756 0 
+L 191 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-67" d="M 181 -300 
+L 753 -353 
+Q 747 -547 800 -644 
+Q 853 -741 969 -794 
+Q 1122 -863 1366 -863 
+Q 1878 -863 2103 -597 
+Q 2250 -419 2375 178 
+L 2431 447 
+Q 1991 0 1494 0 
+Q 991 0 652 370 
+Q 313 741 313 1419 
+Q 313 1978 580 2447 
+Q 847 2916 1215 3155 
+Q 1584 3394 1975 3394 
+Q 2628 3394 2981 2775 
+L 3094 3319 
+L 3613 3319 
+L 2944 116 
+Q 2834 -413 2656 -708 
+Q 2478 -1003 2161 -1165 
+Q 1844 -1328 1428 -1328 
+Q 1028 -1328 739 -1225 
+Q 450 -1122 308 -923 
+Q 166 -725 166 -469 
+Q 166 -391 181 -300 
+z
+M 888 1469 
+Q 888 1128 953 956 
+Q 1047 716 1220 589 
+Q 1394 463 1606 463 
+Q 1884 463 2159 658 
+Q 2434 853 2604 1262 
+Q 2775 1672 2775 2044 
+Q 2775 2453 2548 2695 
+Q 2322 2938 1988 2938 
+Q 1781 2938 1587 2827 
+Q 1394 2716 1226 2489 
+Q 1059 2263 973 1947 
+Q 888 1631 888 1469 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-68" d="M 213 0 
+L 1169 4581 
+L 1734 4581 
+L 1369 2822 
+Q 1684 3128 1956 3261 
+Q 2228 3394 2516 3394 
+Q 2928 3394 3156 3176 
+Q 3384 2959 3384 2603 
+Q 3384 2428 3284 1959 
+L 2875 0 
+L 2309 0 
+L 2731 2009 
+Q 2822 2447 2822 2559 
+Q 2822 2722 2709 2825 
+Q 2597 2928 2384 2928 
+Q 2078 2928 1800 2767 
+Q 1522 2606 1364 2326 
+Q 1206 2047 1075 1425 
+L 778 0 
+L 213 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-2e" d="M 369 0 
+L 503 641 
+L 1144 641 
+L 1006 0 
+L 369 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-71" d="M 2356 375 
+Q 1872 -75 1428 -75 
+Q 966 -75 647 276 
+Q 328 628 328 1275 
+Q 328 1894 570 2394 
+Q 813 2894 1189 3144 
+Q 1566 3394 1966 3394 
+Q 2269 3394 2517 3223 
+Q 2766 3053 2919 2709 
+L 3047 3319 
+L 3534 3319 
+L 2578 -1272 
+L 2013 -1272 
+L 2356 375 
+z
+M 888 1350 
+Q 888 859 1091 623 
+Q 1294 388 1597 388 
+Q 1853 388 2114 600 
+Q 2375 813 2542 1238 
+Q 2709 1663 2709 2059 
+Q 2709 2466 2500 2697 
+Q 2291 2928 1988 2928 
+Q 1691 2928 1469 2734 
+Q 1178 2484 1013 2013 
+Q 888 1650 888 1350 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-62" d="M 213 0 
+L 1169 4581 
+L 1734 4581 
+L 1394 2944 
+Q 1663 3191 1881 3292 
+Q 2100 3394 2338 3394 
+Q 2803 3394 3114 3047 
+Q 3425 2700 3425 2038 
+Q 3425 1597 3300 1231 
+Q 3175 866 2990 617 
+Q 2806 369 2609 220 
+Q 2413 72 2206 -1 
+Q 2000 -75 1809 -75 
+Q 1481 -75 1231 98 
+Q 981 272 841 628 
+L 709 0 
+L 213 0 
+z
+M 1050 1363 
+L 1047 1256 
+Q 1047 831 1250 609 
+Q 1453 388 1756 388 
+Q 2053 388 2301 595 
+Q 2550 803 2709 1243 
+Q 2869 1684 2869 2056 
+Q 2869 2475 2667 2706 
+Q 2466 2938 2169 2938 
+Q 1863 2938 1606 2702 
+Q 1350 2466 1178 1975 
+Q 1050 1609 1050 1363 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-ItalicMT-29" d="M 1269 4659 
+Q 1763 3584 1763 2453 
+Q 1763 1694 1564 1044 
+Q 1366 394 959 -247 
+Q 688 -672 100 -1347 
+L -341 -1347 
+Q 22 -953 431 -243 
+Q 841 466 1023 1148 
+Q 1206 1831 1206 2525 
+Q 1206 3556 847 4659 
+L 1269 4659 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-ItalicMT-51"/>
+     <use xlink:href="#Arial-ItalicMT-75" transform="translate(77.783203 0)"/>
+     <use xlink:href="#Arial-ItalicMT-61" transform="translate(133.398438 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(189.013672 0)"/>
+     <use xlink:href="#Arial-ItalicMT-74" transform="translate(244.628906 0)"/>
+     <use xlink:href="#Arial-ItalicMT-75" transform="translate(272.412109 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6d" transform="translate(328.027344 0)"/>
+     <use xlink:href="#Arial-ItalicMT-20" transform="translate(411.328125 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6d" transform="translate(439.111328 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6f" transform="translate(522.412109 0)"/>
+     <use xlink:href="#Arial-ItalicMT-64" transform="translate(578.027344 0)"/>
+     <use xlink:href="#Arial-ItalicMT-75" transform="translate(633.642578 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6c" transform="translate(689.257812 0)"/>
+     <use xlink:href="#Arial-ItalicMT-65" transform="translate(711.474609 0)"/>
+     <use xlink:href="#Arial-ItalicMT-20" transform="translate(767.089844 0)"/>
+     <use xlink:href="#Arial-ItalicMT-28" transform="translate(794.873047 0)"/>
+     <use xlink:href="#Arial-ItalicMT-50" transform="translate(828.173828 0)"/>
+     <use xlink:href="#Arial-ItalicMT-65" transform="translate(894.873047 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(950.488281 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(1006.103516 0)"/>
+     <use xlink:href="#Arial-ItalicMT-79" transform="translate(1061.71875 0)"/>
+     <use xlink:href="#Arial-ItalicMT-4c" transform="translate(1111.71875 0)"/>
+     <use xlink:href="#Arial-ItalicMT-61" transform="translate(1167.333984 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(1222.949219 0)"/>
+     <use xlink:href="#Arial-ItalicMT-65" transform="translate(1278.564453 0)"/>
+     <use xlink:href="#Arial-ItalicMT-20" transform="translate(1334.179688 0)"/>
+     <use xlink:href="#Arial-ItalicMT-b7" transform="translate(1361.962891 0)"/>
+     <use xlink:href="#Arial-ItalicMT-20" transform="translate(1395.263672 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6c" transform="translate(1423.046875 0)"/>
+     <use xlink:href="#Arial-ItalicMT-69" transform="translate(1445.263672 0)"/>
+     <use xlink:href="#Arial-ItalicMT-67" transform="translate(1467.480469 0)"/>
+     <use xlink:href="#Arial-ItalicMT-68" transform="translate(1523.095703 0)"/>
+     <use xlink:href="#Arial-ItalicMT-74" transform="translate(1578.710938 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(1606.494141 0)"/>
+     <use xlink:href="#Arial-ItalicMT-69" transform="translate(1662.109375 0)"/>
+     <use xlink:href="#Arial-ItalicMT-6e" transform="translate(1684.326172 0)"/>
+     <use xlink:href="#Arial-ItalicMT-67" transform="translate(1739.941406 0)"/>
+     <use xlink:href="#Arial-ItalicMT-2e" transform="translate(1795.556641 0)"/>
+     <use xlink:href="#Arial-ItalicMT-71" transform="translate(1823.339844 0)"/>
+     <use xlink:href="#Arial-ItalicMT-75" transform="translate(1878.955078 0)"/>
+     <use xlink:href="#Arial-ItalicMT-62" transform="translate(1934.570312 0)"/>
+     <use xlink:href="#Arial-ItalicMT-69" transform="translate(1990.185547 0)"/>
+     <use xlink:href="#Arial-ItalicMT-74" transform="translate(2012.402344 0)"/>
+     <use xlink:href="#Arial-ItalicMT-29" transform="translate(2040.185547 0)"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <!-- PHNN — Parallel Hybrid Neural Network Architecture -->
+    <g style="fill: #262626" transform="translate(373.019453 16.505156) scale(0.13 -0.13)">
+     <defs>
+      <path id="Arial-BoldMT-50" d="M 466 0 
+L 466 4581 
+L 1950 4581 
+Q 2794 4581 3050 4513 
+Q 3444 4409 3709 4064 
+Q 3975 3719 3975 3172 
+Q 3975 2750 3822 2462 
+Q 3669 2175 3433 2011 
+Q 3197 1847 2953 1794 
+Q 2622 1728 1994 1728 
+L 1391 1728 
+L 1391 0 
+L 466 0 
+z
+M 1391 3806 
+L 1391 2506 
+L 1897 2506 
+Q 2444 2506 2628 2578 
+Q 2813 2650 2917 2803 
+Q 3022 2956 3022 3159 
+Q 3022 3409 2875 3571 
+Q 2728 3734 2503 3775 
+Q 2338 3806 1838 3806 
+L 1391 3806 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-48" d="M 469 0 
+L 469 4581 
+L 1394 4581 
+L 1394 2778 
+L 3206 2778 
+L 3206 4581 
+L 4131 4581 
+L 4131 0 
+L 3206 0 
+L 3206 2003 
+L 1394 2003 
+L 1394 0 
+L 469 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-4e" d="M 475 0 
+L 475 4581 
+L 1375 4581 
+L 3250 1522 
+L 3250 4581 
+L 4109 4581 
+L 4109 0 
+L 3181 0 
+L 1334 2988 
+L 1334 0 
+L 475 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-20" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-2014" d="M 0 1331 
+L 0 1988 
+L 6400 1988 
+L 6400 1331 
+L 0 1331 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-61" d="M 1116 2306 
+L 319 2450 
+Q 453 2931 781 3162 
+Q 1109 3394 1756 3394 
+Q 2344 3394 2631 3255 
+Q 2919 3116 3036 2902 
+Q 3153 2688 3153 2116 
+L 3144 1091 
+Q 3144 653 3186 445 
+Q 3228 238 3344 0 
+L 2475 0 
+Q 2441 88 2391 259 
+Q 2369 338 2359 363 
+Q 2134 144 1878 34 
+Q 1622 -75 1331 -75 
+Q 819 -75 523 203 
+Q 228 481 228 906 
+Q 228 1188 362 1408 
+Q 497 1628 739 1745 
+Q 981 1863 1438 1950 
+Q 2053 2066 2291 2166 
+L 2291 2253 
+Q 2291 2506 2166 2614 
+Q 2041 2722 1694 2722 
+Q 1459 2722 1328 2630 
+Q 1197 2538 1116 2306 
+z
+M 2291 1594 
+Q 2122 1538 1756 1459 
+Q 1391 1381 1278 1306 
+Q 1106 1184 1106 997 
+Q 1106 813 1243 678 
+Q 1381 544 1594 544 
+Q 1831 544 2047 700 
+Q 2206 819 2256 991 
+Q 2291 1103 2291 1419 
+L 2291 1594 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-72" d="M 1300 0 
+L 422 0 
+L 422 3319 
+L 1238 3319 
+L 1238 2847 
+Q 1447 3181 1614 3287 
+Q 1781 3394 1994 3394 
+Q 2294 3394 2572 3228 
+L 2300 2463 
+Q 2078 2606 1888 2606 
+Q 1703 2606 1575 2504 
+Q 1447 2403 1373 2137 
+Q 1300 1872 1300 1025 
+L 1300 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6c" d="M 459 0 
+L 459 4581 
+L 1338 4581 
+L 1338 0 
+L 459 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-65" d="M 2381 1056 
+L 3256 909 
+Q 3088 428 2723 176 
+Q 2359 -75 1813 -75 
+Q 947 -75 531 491 
+Q 203 944 203 1634 
+Q 203 2459 634 2926 
+Q 1066 3394 1725 3394 
+Q 2466 3394 2894 2905 
+Q 3322 2416 3303 1406 
+L 1103 1406 
+Q 1113 1016 1316 798 
+Q 1519 581 1822 581 
+Q 2028 581 2168 693 
+Q 2309 806 2381 1056 
+z
+M 2431 1944 
+Q 2422 2325 2234 2523 
+Q 2047 2722 1778 2722 
+Q 1491 2722 1303 2513 
+Q 1116 2303 1119 1944 
+L 2431 1944 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-79" d="M 44 3319 
+L 978 3319 
+L 1772 963 
+L 2547 3319 
+L 3456 3319 
+L 2284 125 
+L 2075 -453 
+Q 1959 -744 1854 -897 
+Q 1750 -1050 1614 -1145 
+Q 1478 -1241 1279 -1294 
+Q 1081 -1347 831 -1347 
+Q 578 -1347 334 -1294 
+L 256 -606 
+Q 463 -647 628 -647 
+Q 934 -647 1081 -467 
+Q 1228 -288 1306 -9 
+L 44 3319 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-62" d="M 422 0 
+L 422 4581 
+L 1300 4581 
+L 1300 2931 
+Q 1706 3394 2263 3394 
+Q 2869 3394 3266 2955 
+Q 3663 2516 3663 1694 
+Q 3663 844 3258 384 
+Q 2853 -75 2275 -75 
+Q 1991 -75 1714 67 
+Q 1438 209 1238 488 
+L 1238 0 
+L 422 0 
+z
+M 1294 1731 
+Q 1294 1216 1456 969 
+Q 1684 619 2063 619 
+Q 2353 619 2558 867 
+Q 2763 1116 2763 1650 
+Q 2763 2219 2556 2470 
+Q 2350 2722 2028 2722 
+Q 1713 2722 1503 2476 
+Q 1294 2231 1294 1731 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-69" d="M 459 3769 
+L 459 4581 
+L 1338 4581 
+L 1338 3769 
+L 459 3769 
+z
+M 459 0 
+L 459 3319 
+L 1338 3319 
+L 1338 0 
+L 459 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-64" d="M 3503 0 
+L 2688 0 
+L 2688 488 
+Q 2484 203 2207 64 
+Q 1931 -75 1650 -75 
+Q 1078 -75 670 386 
+Q 263 847 263 1672 
+Q 263 2516 659 2955 
+Q 1056 3394 1663 3394 
+Q 2219 3394 2625 2931 
+L 2625 4581 
+L 3503 4581 
+L 3503 0 
+z
+M 1159 1731 
+Q 1159 1200 1306 963 
+Q 1519 619 1900 619 
+Q 2203 619 2415 876 
+Q 2628 1134 2628 1647 
+Q 2628 2219 2422 2470 
+Q 2216 2722 1894 2722 
+Q 1581 2722 1370 2473 
+Q 1159 2225 1159 1731 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-75" d="M 2644 0 
+L 2644 497 
+Q 2463 231 2167 78 
+Q 1872 -75 1544 -75 
+Q 1209 -75 943 72 
+Q 678 219 559 484 
+Q 441 750 441 1219 
+L 441 3319 
+L 1319 3319 
+L 1319 1794 
+Q 1319 1094 1367 936 
+Q 1416 778 1544 686 
+Q 1672 594 1869 594 
+Q 2094 594 2272 717 
+Q 2450 841 2515 1023 
+Q 2581 1206 2581 1919 
+L 2581 3319 
+L 3459 3319 
+L 3459 0 
+L 2644 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-74" d="M 1981 3319 
+L 1981 2619 
+L 1381 2619 
+L 1381 1281 
+Q 1381 875 1398 808 
+Q 1416 741 1477 697 
+Q 1538 653 1625 653 
+Q 1747 653 1978 738 
+L 2053 56 
+Q 1747 -75 1359 -75 
+Q 1122 -75 931 4 
+Q 741 84 652 211 
+Q 563 338 528 553 
+Q 500 706 500 1172 
+L 500 2619 
+L 97 2619 
+L 97 3319 
+L 500 3319 
+L 500 3978 
+L 1381 4491 
+L 1381 3319 
+L 1981 3319 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-77" d="M 1078 0 
+L 28 3319 
+L 881 3319 
+L 1503 1144 
+L 2075 3319 
+L 2922 3319 
+L 3475 1144 
+L 4109 3319 
+L 4975 3319 
+L 3909 0 
+L 3066 0 
+L 2494 2134 
+L 1931 0 
+L 1078 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6f" d="M 256 1706 
+Q 256 2144 472 2553 
+Q 688 2963 1083 3178 
+Q 1478 3394 1966 3394 
+Q 2719 3394 3200 2905 
+Q 3681 2416 3681 1669 
+Q 3681 916 3195 420 
+Q 2709 -75 1972 -75 
+Q 1516 -75 1102 131 
+Q 688 338 472 736 
+Q 256 1134 256 1706 
+z
+M 1156 1659 
+Q 1156 1166 1390 903 
+Q 1625 641 1969 641 
+Q 2313 641 2545 903 
+Q 2778 1166 2778 1666 
+Q 2778 2153 2545 2415 
+Q 2313 2678 1969 2678 
+Q 1625 2678 1390 2415 
+Q 1156 2153 1156 1659 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6b" d="M 428 0 
+L 428 4581 
+L 1306 4581 
+L 1306 2150 
+L 2334 3319 
+L 3416 3319 
+L 2281 2106 
+L 3497 0 
+L 2550 0 
+L 1716 1491 
+L 1306 1063 
+L 1306 0 
+L 428 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-41" d="M 4597 0 
+L 3591 0 
+L 3191 1041 
+L 1359 1041 
+L 981 0 
+L 0 0 
+L 1784 4581 
+L 2763 4581 
+L 4597 0 
+z
+M 2894 1813 
+L 2263 3513 
+L 1644 1813 
+L 2894 1813 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-63" d="M 3353 2338 
+L 2488 2181 
+Q 2444 2441 2289 2572 
+Q 2134 2703 1888 2703 
+Q 1559 2703 1364 2476 
+Q 1169 2250 1169 1719 
+Q 1169 1128 1367 884 
+Q 1566 641 1900 641 
+Q 2150 641 2309 783 
+Q 2469 925 2534 1272 
+L 3397 1125 
+Q 3263 531 2881 228 
+Q 2500 -75 1859 -75 
+Q 1131 -75 698 384 
+Q 266 844 266 1656 
+Q 266 2478 700 2936 
+Q 1134 3394 1875 3394 
+Q 2481 3394 2839 3133 
+Q 3197 2872 3353 2338 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-68" d="M 1334 4581 
+L 1334 2897 
+Q 1759 3394 2350 3394 
+Q 2653 3394 2897 3281 
+Q 3141 3169 3264 2994 
+Q 3388 2819 3433 2606 
+Q 3478 2394 3478 1947 
+L 3478 0 
+L 2600 0 
+L 2600 1753 
+Q 2600 2275 2550 2415 
+Q 2500 2556 2373 2639 
+Q 2247 2722 2056 2722 
+Q 1838 2722 1666 2615 
+Q 1494 2509 1414 2295 
+Q 1334 2081 1334 1663 
+L 1334 0 
+L 456 0 
+L 456 4581 
+L 1334 4581 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-50"/>
+     <use xlink:href="#Arial-BoldMT-48" transform="translate(66.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-4e" transform="translate(138.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-4e" transform="translate(211.132812 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(283.349609 0)"/>
+     <use xlink:href="#Arial-BoldMT-2014" transform="translate(311.132812 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(411.132812 0)"/>
+     <use xlink:href="#Arial-BoldMT-50" transform="translate(438.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(505.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(561.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(600.146484 0)"/>
+     <use xlink:href="#Arial-BoldMT-6c" transform="translate(655.761719 0)"/>
+     <use xlink:href="#Arial-BoldMT-6c" transform="translate(683.544922 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(711.328125 0)"/>
+     <use xlink:href="#Arial-BoldMT-6c" transform="translate(766.943359 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(794.726562 0)"/>
+     <use xlink:href="#Arial-BoldMT-48" transform="translate(822.509766 0)"/>
+     <use xlink:href="#Arial-BoldMT-79" transform="translate(894.726562 0)"/>
+     <use xlink:href="#Arial-BoldMT-62" transform="translate(950.341797 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(1011.425781 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(1050.341797 0)"/>
+     <use xlink:href="#Arial-BoldMT-64" transform="translate(1078.125 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(1139.208984 0)"/>
+     <use xlink:href="#Arial-BoldMT-4e" transform="translate(1166.992188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(1239.208984 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(1294.824219 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(1355.908203 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(1394.824219 0)"/>
+     <use xlink:href="#Arial-BoldMT-6c" transform="translate(1450.439453 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(1478.222656 0)"/>
+     <use xlink:href="#Arial-BoldMT-4e" transform="translate(1506.005859 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(1578.222656 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(1633.837891 0)"/>
+     <use xlink:href="#Arial-BoldMT-77" transform="translate(1667.138672 0)"/>
+     <use xlink:href="#Arial-BoldMT-6f" transform="translate(1744.921875 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(1806.005859 0)"/>
+     <use xlink:href="#Arial-BoldMT-6b" transform="translate(1844.921875 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(1900.537109 0)"/>
+     <use xlink:href="#Arial-BoldMT-41" transform="translate(1924.570312 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(1996.787109 0)"/>
+     <use xlink:href="#Arial-BoldMT-63" transform="translate(2035.703125 0)"/>
+     <use xlink:href="#Arial-BoldMT-68" transform="translate(2091.318359 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(2152.402344 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(2180.185547 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(2213.486328 0)"/>
+     <use xlink:href="#Arial-BoldMT-63" transform="translate(2269.101562 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(2324.716797 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(2358.017578 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(2419.101562 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(2458.017578 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- Input -->
+    <g style="fill: #2d3436" transform="translate(51.443816 164.621383) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-49" d="M 438 0 
+L 438 4581 
+L 1363 4581 
+L 1363 0 
+L 438 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6e" d="M 3478 0 
+L 2600 0 
+L 2600 1694 
+Q 2600 2231 2544 2389 
+Q 2488 2547 2361 2634 
+Q 2234 2722 2056 2722 
+Q 1828 2722 1647 2597 
+Q 1466 2472 1398 2265 
+Q 1331 2059 1331 1503 
+L 1331 0 
+L 453 0 
+L 453 3319 
+L 1269 3319 
+L 1269 2831 
+Q 1703 3394 2363 3394 
+Q 2653 3394 2893 3289 
+Q 3134 3184 3257 3021 
+Q 3381 2859 3429 2653 
+Q 3478 2447 3478 2063 
+L 3478 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-70" d="M 434 3319 
+L 1253 3319 
+L 1253 2831 
+Q 1413 3081 1684 3237 
+Q 1956 3394 2288 3394 
+Q 2866 3394 3269 2941 
+Q 3672 2488 3672 1678 
+Q 3672 847 3265 386 
+Q 2859 -75 2281 -75 
+Q 2006 -75 1782 34 
+Q 1559 144 1313 409 
+L 1313 -1263 
+L 434 -1263 
+L 434 3319 
+z
+M 1303 1716 
+Q 1303 1156 1525 889 
+Q 1747 622 2066 622 
+Q 2372 622 2575 867 
+Q 2778 1113 2778 1672 
+Q 2778 2194 2568 2447 
+Q 2359 2700 2050 2700 
+Q 1728 2700 1515 2451 
+Q 1303 2203 1303 1716 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-49"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(27.783203 0)"/>
+     <use xlink:href="#Arial-BoldMT-70" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(211.035156 0)"/>
+    </g>
+    <!-- (8 features) -->
+    <g style="fill: #2d3436" transform="translate(38.918933 173.724086) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-28" d="M 1916 -1347 
+L 1313 -1347 
+Q 834 -625 584 153 
+Q 334 931 334 1659 
+Q 334 2563 644 3369 
+Q 913 4069 1325 4659 
+L 1925 4659 
+Q 1497 3713 1336 3048 
+Q 1175 2384 1175 1641 
+Q 1175 1128 1270 590 
+Q 1366 53 1531 -431 
+Q 1641 -750 1916 -1347 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-38" d="M 1025 2472 
+Q 684 2616 529 2867 
+Q 375 3119 375 3419 
+Q 375 3931 733 4265 
+Q 1091 4600 1750 4600 
+Q 2403 4600 2764 4265 
+Q 3125 3931 3125 3419 
+Q 3125 3100 2959 2851 
+Q 2794 2603 2494 2472 
+Q 2875 2319 3073 2025 
+Q 3272 1731 3272 1347 
+Q 3272 713 2867 316 
+Q 2463 -81 1791 -81 
+Q 1166 -81 750 247 
+Q 259 634 259 1309 
+Q 259 1681 443 1992 
+Q 628 2303 1025 2472 
+z
+M 1206 3356 
+Q 1206 3094 1354 2947 
+Q 1503 2800 1750 2800 
+Q 2000 2800 2150 2948 
+Q 2300 3097 2300 3359 
+Q 2300 3606 2151 3754 
+Q 2003 3903 1759 3903 
+Q 1506 3903 1356 3753 
+Q 1206 3603 1206 3356 
+z
+M 1125 1394 
+Q 1125 1031 1311 828 
+Q 1497 625 1775 625 
+Q 2047 625 2225 820 
+Q 2403 1016 2403 1384 
+Q 2403 1706 2222 1901 
+Q 2041 2097 1763 2097 
+Q 1441 2097 1283 1875 
+Q 1125 1653 1125 1394 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-66" d="M 75 3319 
+L 563 3319 
+L 563 3569 
+Q 563 3988 652 4194 
+Q 741 4400 980 4529 
+Q 1219 4659 1584 4659 
+Q 1959 4659 2319 4547 
+L 2200 3934 
+Q 1991 3984 1797 3984 
+Q 1606 3984 1523 3895 
+Q 1441 3806 1441 3553 
+L 1441 3319 
+L 2097 3319 
+L 2097 2628 
+L 1441 2628 
+L 1441 0 
+L 563 0 
+L 563 2628 
+L 75 2628 
+L 75 3319 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-73" d="M 150 947 
+L 1031 1081 
+Q 1088 825 1259 692 
+Q 1431 559 1741 559 
+Q 2081 559 2253 684 
+Q 2369 772 2369 919 
+Q 2369 1019 2306 1084 
+Q 2241 1147 2013 1200 
+Q 950 1434 666 1628 
+Q 272 1897 272 2375 
+Q 272 2806 612 3100 
+Q 953 3394 1669 3394 
+Q 2350 3394 2681 3172 
+Q 3013 2950 3138 2516 
+L 2309 2363 
+Q 2256 2556 2107 2659 
+Q 1959 2763 1684 2763 
+Q 1338 2763 1188 2666 
+Q 1088 2597 1088 2488 
+Q 1088 2394 1175 2328 
+Q 1294 2241 1995 2081 
+Q 2697 1922 2975 1691 
+Q 3250 1456 3250 1038 
+Q 3250 581 2869 253 
+Q 2488 -75 1741 -75 
+Q 1063 -75 667 200 
+Q 272 475 150 947 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-29" d="M 216 -1347 
+Q 475 -791 581 -494 
+Q 688 -197 778 190 
+Q 869 578 912 926 
+Q 956 1275 956 1641 
+Q 956 2384 797 3048 
+Q 638 3713 209 4659 
+L 806 4659 
+Q 1278 3988 1539 3234 
+Q 1800 2481 1800 1706 
+Q 1800 1053 1594 306 
+Q 1359 -531 822 -1347 
+L 216 -1347 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-28"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(33.300781 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(88.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-66" transform="translate(116.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(150 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(261.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(294.53125 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(355.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(394.53125 0)"/>
+     <use xlink:href="#Arial-BoldMT-73" transform="translate(450.146484 0)"/>
+     <use xlink:href="#Arial-BoldMT-29" transform="translate(505.761719 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- Linear 8→8 -->
+    <g style="fill: #2d3436" transform="translate(158.413051 101.912583) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-4c" d="M 491 0 
+L 491 4544 
+L 1416 4544 
+L 1416 772 
+L 3716 772 
+L 3716 0 
+L 491 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-2192" d="M 4859 2738 
+Q 5275 2284 5578 2048 
+Q 5881 1813 6150 1697 
+L 6150 1556 
+Q 5841 1406 5550 1173 
+Q 5259 941 4856 491 
+L 4616 491 
+Q 4909 1119 5231 1456 
+L 247 1456 
+L 247 1772 
+L 5231 1772 
+Q 4994 2072 4900 2220 
+Q 4806 2369 4622 2738 
+L 4859 2738 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-4c"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(61.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(300.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(327.880859 0)"/>
+     <use xlink:href="#Arial-BoldMT-2192" transform="translate(383.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(483.496094 0)"/>
+    </g>
+    <!-- (vqc_proj) -->
+    <g style="fill: #2d3436" transform="translate(160.781098 111.015286) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-76" d="M 1372 0 
+L 34 3319 
+L 956 3319 
+L 1581 1625 
+L 1763 1059 
+Q 1834 1275 1853 1344 
+Q 1897 1484 1947 1625 
+L 2578 3319 
+L 3481 3319 
+L 2163 0 
+L 1372 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-71" d="M 2628 -1263 
+L 2628 406 
+Q 2456 184 2200 54 
+Q 1944 -75 1647 -75 
+Q 1081 -75 716 350 
+Q 284 847 284 1697 
+Q 284 2497 689 2945 
+Q 1094 3394 1694 3394 
+Q 2025 3394 2267 3253 
+Q 2509 3113 2697 2828 
+L 2697 3319 
+L 3506 3319 
+L 3506 -1263 
+L 2628 -1263 
+z
+M 2656 1700 
+Q 2656 2209 2448 2457 
+Q 2241 2706 1928 2706 
+Q 1609 2706 1395 2453 
+Q 1181 2200 1181 1650 
+Q 1181 1103 1387 861 
+Q 1594 619 1897 619 
+Q 2200 619 2428 891 
+Q 2656 1163 2656 1700 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-5f" d="M -59 -1266 
+L -59 -697 
+L 3591 -697 
+L 3591 -1266 
+L -59 -1266 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6a" d="M 441 3769 
+L 441 4581 
+L 1319 4581 
+L 1319 3769 
+L 441 3769 
+z
+M 1319 3319 
+L 1319 103 
+Q 1319 -531 1236 -792 
+Q 1153 -1053 917 -1200 
+Q 681 -1347 316 -1347 
+Q 184 -1347 32 -1323 
+Q -119 -1300 -294 -1253 
+L -141 -503 
+Q -78 -516 -23 -523 
+Q 31 -531 78 -531 
+Q 213 -531 298 -473 
+Q 384 -416 412 -334 
+Q 441 -253 441 153 
+L 441 3319 
+L 1319 3319 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-28"/>
+     <use xlink:href="#Arial-BoldMT-76" transform="translate(33.300781 0)"/>
+     <use xlink:href="#Arial-BoldMT-71" transform="translate(88.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-63" transform="translate(150 0)"/>
+     <use xlink:href="#Arial-BoldMT-5f" transform="translate(205.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-70" transform="translate(261.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(322.314453 0)"/>
+     <use xlink:href="#Arial-BoldMT-6f" transform="translate(361.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-6a" transform="translate(422.314453 0)"/>
+     <use xlink:href="#Arial-BoldMT-29" transform="translate(450.097656 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- PiSigmoid -->
+    <g style="fill: #2d3436" transform="translate(276.627936 102.026536) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-53" d="M 231 1491 
+L 1131 1578 
+Q 1213 1125 1461 912 
+Q 1709 700 2131 700 
+Q 2578 700 2804 889 
+Q 3031 1078 3031 1331 
+Q 3031 1494 2936 1608 
+Q 2841 1722 2603 1806 
+Q 2441 1863 1863 2006 
+Q 1119 2191 819 2459 
+Q 397 2838 397 3381 
+Q 397 3731 595 4036 
+Q 794 4341 1167 4500 
+Q 1541 4659 2069 4659 
+Q 2931 4659 3367 4281 
+Q 3803 3903 3825 3272 
+L 2900 3231 
+Q 2841 3584 2645 3739 
+Q 2450 3894 2059 3894 
+Q 1656 3894 1428 3728 
+Q 1281 3622 1281 3444 
+Q 1281 3281 1419 3166 
+Q 1594 3019 2269 2859 
+Q 2944 2700 3267 2529 
+Q 3591 2359 3773 2064 
+Q 3956 1769 3956 1334 
+Q 3956 941 3737 597 
+Q 3519 253 3119 86 
+Q 2719 -81 2122 -81 
+Q 1253 -81 787 320 
+Q 322 722 231 1491 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-67" d="M 378 -219 
+L 1381 -341 
+Q 1406 -516 1497 -581 
+Q 1622 -675 1891 -675 
+Q 2234 -675 2406 -572 
+Q 2522 -503 2581 -350 
+Q 2622 -241 2622 53 
+L 2622 538 
+Q 2228 0 1628 0 
+Q 959 0 569 566 
+Q 263 1013 263 1678 
+Q 263 2513 664 2953 
+Q 1066 3394 1663 3394 
+Q 2278 3394 2678 2853 
+L 2678 3319 
+L 3500 3319 
+L 3500 341 
+Q 3500 -247 3403 -537 
+Q 3306 -828 3131 -993 
+Q 2956 -1159 2664 -1253 
+Q 2372 -1347 1925 -1347 
+Q 1081 -1347 728 -1058 
+Q 375 -769 375 -325 
+Q 375 -281 378 -219 
+z
+M 1163 1728 
+Q 1163 1200 1367 954 
+Q 1572 709 1872 709 
+Q 2194 709 2416 961 
+Q 2638 1213 2638 1706 
+Q 2638 2222 2425 2472 
+Q 2213 2722 1888 2722 
+Q 1572 2722 1367 2476 
+Q 1163 2231 1163 1728 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-6d" d="M 394 3319 
+L 1203 3319 
+L 1203 2866 
+Q 1638 3394 2238 3394 
+Q 2556 3394 2790 3262 
+Q 3025 3131 3175 2866 
+Q 3394 3131 3647 3262 
+Q 3900 3394 4188 3394 
+Q 4553 3394 4806 3245 
+Q 5059 3097 5184 2809 
+Q 5275 2597 5275 2122 
+L 5275 0 
+L 4397 0 
+L 4397 1897 
+Q 4397 2391 4306 2534 
+Q 4184 2722 3931 2722 
+Q 3747 2722 3584 2609 
+Q 3422 2497 3350 2280 
+Q 3278 2063 3278 1594 
+L 3278 0 
+L 2400 0 
+L 2400 1819 
+Q 2400 2303 2353 2443 
+Q 2306 2584 2207 2653 
+Q 2109 2722 1941 2722 
+Q 1738 2722 1575 2612 
+Q 1413 2503 1342 2297 
+Q 1272 2091 1272 1613 
+L 1272 0 
+L 394 0 
+L 394 3319 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-50"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(66.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-53" transform="translate(94.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(161.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-67" transform="translate(188.964844 0)"/>
+     <use xlink:href="#Arial-BoldMT-6d" transform="translate(250.048828 0)"/>
+     <use xlink:href="#Arial-BoldMT-6f" transform="translate(338.964844 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(400.048828 0)"/>
+     <use xlink:href="#Arial-BoldMT-64" transform="translate(427.832031 0)"/>
+    </g>
+    <!-- ×π -->
+    <g style="fill: #2d3436" transform="translate(291.67028 111.116489) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-d7" d="M 347 1313 
+L 1291 2256 
+L 341 3203 
+L 922 3784 
+L 1872 2838 
+L 2816 3781 
+L 3381 3213 
+L 2438 2269 
+L 3391 1316 
+L 2809 734 
+L 1856 1688 
+L 913 744 
+L 347 1313 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-3c0" d="M 150 3319 
+L 4747 3319 
+L 4747 2591 
+L 3866 2591 
+L 3866 0 
+L 2988 0 
+L 2988 2591 
+L 1909 2591 
+L 1909 0 
+L 1031 0 
+L 1031 2591 
+L 150 2591 
+L 150 3319 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-d7"/>
+     <use xlink:href="#Arial-BoldMT-3c0" transform="translate(58.398438 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- VQC -->
+    <g style="fill: #2d3436" transform="translate(424.764311 97.455262) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-56" d="M 1634 0 
+L -3 4581 
+L 1000 4581 
+L 2159 1191 
+L 3281 4581 
+L 4263 4581 
+L 2622 0 
+L 1634 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-51" d="M 4153 581 
+Q 4494 338 4894 194 
+L 4553 -459 
+Q 4344 -397 4144 -288 
+Q 4100 -266 3528 119 
+Q 3078 -78 2531 -78 
+Q 1475 -78 876 544 
+Q 278 1166 278 2291 
+Q 278 3413 878 4036 
+Q 1478 4659 2506 4659 
+Q 3525 4659 4122 4036 
+Q 4719 3413 4719 2291 
+Q 4719 1697 4553 1247 
+Q 4428 903 4153 581 
+z
+M 3409 1103 
+Q 3588 1313 3677 1609 
+Q 3766 1906 3766 2291 
+Q 3766 3084 3416 3476 
+Q 3066 3869 2500 3869 
+Q 1934 3869 1582 3475 
+Q 1231 3081 1231 2291 
+Q 1231 1488 1582 1089 
+Q 1934 691 2472 691 
+Q 2672 691 2850 756 
+Q 2569 941 2278 1044 
+L 2538 1572 
+Q 2994 1416 3409 1103 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-43" d="M 3397 1684 
+L 4294 1400 
+Q 4088 650 3608 286 
+Q 3128 -78 2391 -78 
+Q 1478 -78 890 545 
+Q 303 1169 303 2250 
+Q 303 3394 893 4026 
+Q 1484 4659 2447 4659 
+Q 3288 4659 3813 4163 
+Q 4125 3869 4281 3319 
+L 3366 3100 
+Q 3284 3456 3026 3662 
+Q 2769 3869 2400 3869 
+Q 1891 3869 1573 3503 
+Q 1256 3138 1256 2319 
+Q 1256 1450 1568 1081 
+Q 1881 713 2381 713 
+Q 2750 713 3015 947 
+Q 3281 1181 3397 1684 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-56"/>
+     <use xlink:href="#Arial-BoldMT-51" transform="translate(66.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-43" transform="translate(144.482422 0)"/>
+    </g>
+    <!-- 8 qubits · 2 layers -->
+    <g style="fill: #2d3436" transform="translate(398.074311 106.463934) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-b7" d="M 625 1791 
+L 625 2669 
+L 1503 2669 
+L 1503 1791 
+L 625 1791 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-32" d="M 3238 816 
+L 3238 0 
+L 159 0 
+Q 209 463 459 877 
+Q 709 1291 1447 1975 
+Q 2041 2528 2175 2725 
+Q 2356 2997 2356 3263 
+Q 2356 3556 2198 3714 
+Q 2041 3872 1763 3872 
+Q 1488 3872 1325 3706 
+Q 1163 3541 1138 3156 
+L 263 3244 
+Q 341 3969 753 4284 
+Q 1166 4600 1784 4600 
+Q 2463 4600 2850 4234 
+Q 3238 3869 3238 3325 
+Q 3238 3016 3127 2736 
+Q 3016 2456 2775 2150 
+Q 2616 1947 2200 1565 
+Q 1784 1184 1673 1059 
+Q 1563 934 1494 816 
+L 3238 816 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-38"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(55.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-71" transform="translate(83.398438 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(144.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-62" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(266.650391 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(294.433594 0)"/>
+     <use xlink:href="#Arial-BoldMT-73" transform="translate(327.734375 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(383.349609 0)"/>
+     <use xlink:href="#Arial-BoldMT-b7" transform="translate(411.132812 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(444.433594 0)"/>
+     <use xlink:href="#Arial-BoldMT-32" transform="translate(472.216797 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(527.832031 0)"/>
+     <use xlink:href="#Arial-BoldMT-6c" transform="translate(555.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(583.398438 0)"/>
+     <use xlink:href="#Arial-BoldMT-79" transform="translate(639.013672 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(694.628906 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(750.244141 0)"/>
+     <use xlink:href="#Arial-BoldMT-73" transform="translate(789.160156 0)"/>
+    </g>
+    <!-- 48 params -->
+    <g style="fill: #2d3436" transform="translate(412.947319 115.584169) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-34" d="M 1994 0 
+L 1994 922 
+L 119 922 
+L 119 1691 
+L 2106 4600 
+L 2844 4600 
+L 2844 1694 
+L 3413 1694 
+L 3413 922 
+L 2844 922 
+L 2844 0 
+L 1994 0 
+z
+M 1994 1694 
+L 1994 3259 
+L 941 1694 
+L 1994 1694 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-34"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(55.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(111.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-70" transform="translate(139.013672 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(200.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(255.712891 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(294.628906 0)"/>
+     <use xlink:href="#Arial-BoldMT-6d" transform="translate(350.244141 0)"/>
+     <use xlink:href="#Arial-BoldMT-73" transform="translate(439.160156 0)"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- &lt;Z0&gt; -->
+    <g style="fill: #2d3436" transform="translate(553.789798 102.03052) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-3c" d="M 3438 522 
+L 297 1888 
+L 297 2644 
+L 3438 4003 
+L 3438 3113 
+L 1247 2275 
+L 3438 1406 
+L 3438 522 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-5a" d="M 69 0 
+L 69 834 
+L 2475 3806 
+L 341 3806 
+L 341 4581 
+L 3694 4581 
+L 3694 3863 
+L 1184 772 
+L 3791 772 
+L 3791 0 
+L 69 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-30" d="M 1756 4600 
+Q 2422 4600 2797 4125 
+Q 3244 3563 3244 2259 
+Q 3244 959 2794 391 
+Q 2422 -78 1756 -78 
+Q 1088 -78 678 436 
+Q 269 950 269 2269 
+Q 269 3563 719 4131 
+Q 1091 4600 1756 4600 
+z
+M 1756 3872 
+Q 1597 3872 1472 3770 
+Q 1347 3669 1278 3406 
+Q 1188 3066 1188 2259 
+Q 1188 1453 1269 1151 
+Q 1350 850 1473 750 
+Q 1597 650 1756 650 
+Q 1916 650 2041 751 
+Q 2166 853 2234 1116 
+Q 2325 1453 2325 2259 
+Q 2325 3066 2244 3367 
+Q 2163 3669 2039 3770 
+Q 1916 3872 1756 3872 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-3e" d="M 297 519 
+L 297 1403 
+L 2491 2266 
+L 297 3119 
+L 297 3997 
+L 3441 2638 
+L 3441 1888 
+L 297 519 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-3c"/>
+     <use xlink:href="#Arial-BoldMT-5a" transform="translate(58.398438 0)"/>
+     <use xlink:href="#Arial-BoldMT-30" transform="translate(119.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-3e" transform="translate(175.097656 0)"/>
+    </g>
+    <!-- Measurement -->
+    <g style="fill: #2d3436" transform="translate(536.316322 111.008911) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-4d" d="M 453 0 
+L 453 4581 
+L 1838 4581 
+L 2669 1456 
+L 3491 4581 
+L 4878 4581 
+L 4878 0 
+L 4019 0 
+L 4019 3606 
+L 3109 0 
+L 2219 0 
+L 1313 3606 
+L 1313 0 
+L 453 0 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-4d"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(83.300781 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(138.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-73" transform="translate(194.53125 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(250.146484 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(311.230469 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(350.146484 0)"/>
+     <use xlink:href="#Arial-BoldMT-6d" transform="translate(405.761719 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(494.677734 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(550.292969 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(611.376953 0)"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <!-- Linear 8→16 -->
+    <g style="fill: #2d3436" transform="translate(193.605781 227.44812) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-31" d="M 2519 0 
+L 1641 0 
+L 1641 3309 
+Q 1159 2859 506 2644 
+L 506 3441 
+Q 850 3553 1253 3867 
+Q 1656 4181 1806 4600 
+L 2519 4600 
+L 2519 0 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-36" d="M 3247 3459 
+L 2397 3366 
+Q 2366 3628 2234 3753 
+Q 2103 3878 1894 3878 
+Q 1616 3878 1423 3628 
+Q 1231 3378 1181 2588 
+Q 1509 2975 1997 2975 
+Q 2547 2975 2939 2556 
+Q 3331 2138 3331 1475 
+Q 3331 772 2918 347 
+Q 2506 -78 1859 -78 
+Q 1166 -78 719 461 
+Q 272 1000 272 2228 
+Q 272 3488 737 4044 
+Q 1203 4600 1947 4600 
+Q 2469 4600 2811 4308 
+Q 3153 4016 3247 3459 
+z
+M 1256 1544 
+Q 1256 1116 1453 883 
+Q 1650 650 1903 650 
+Q 2147 650 2309 840 
+Q 2472 1031 2472 1466 
+Q 2472 1913 2297 2120 
+Q 2122 2328 1859 2328 
+Q 1606 2328 1431 2129 
+Q 1256 1931 1256 1544 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-4c"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(61.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(300.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(327.880859 0)"/>
+     <use xlink:href="#Arial-BoldMT-2192" transform="translate(383.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-31" transform="translate(483.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-36" transform="translate(539.111328 0)"/>
+    </g>
+    <!-- ReLU -->
+    <g style="fill: #2d3436" transform="translate(207.782187 236.426511) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-52" d="M 469 0 
+L 469 4581 
+L 2416 4581 
+Q 3150 4581 3483 4457 
+Q 3816 4334 4016 4018 
+Q 4216 3703 4216 3297 
+Q 4216 2781 3912 2445 
+Q 3609 2109 3006 2022 
+Q 3306 1847 3501 1637 
+Q 3697 1428 4028 894 
+L 4588 0 
+L 3481 0 
+L 2813 997 
+Q 2456 1531 2325 1670 
+Q 2194 1809 2047 1861 
+Q 1900 1913 1581 1913 
+L 1394 1913 
+L 1394 0 
+L 469 0 
+z
+M 1394 2644 
+L 2078 2644 
+Q 2744 2644 2909 2700 
+Q 3075 2756 3169 2893 
+Q 3263 3031 3263 3238 
+Q 3263 3469 3139 3611 
+Q 3016 3753 2791 3791 
+Q 2678 3806 2116 3806 
+L 1394 3806 
+L 1394 2644 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-55" d="M 459 4581 
+L 1384 4581 
+L 1384 2100 
+Q 1384 1509 1419 1334 
+Q 1478 1053 1701 883 
+Q 1925 713 2313 713 
+Q 2706 713 2906 873 
+Q 3106 1034 3147 1268 
+Q 3188 1503 3188 2047 
+L 3188 4581 
+L 4113 4581 
+L 4113 2175 
+Q 4113 1350 4038 1009 
+Q 3963 669 3761 434 
+Q 3559 200 3221 61 
+Q 2884 -78 2341 -78 
+Q 1684 -78 1345 73 
+Q 1006 225 809 467 
+Q 613 709 550 975 
+Q 459 1369 459 2138 
+L 459 4581 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-52"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(72.216797 0)"/>
+     <use xlink:href="#Arial-BoldMT-4c" transform="translate(127.832031 0)"/>
+     <use xlink:href="#Arial-BoldMT-55" transform="translate(188.916016 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- Linear 16→8 -->
+    <g style="fill: #2d3436" transform="translate(330.173523 227.44812) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-4c"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(61.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(300.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-31" transform="translate(327.880859 0)"/>
+     <use xlink:href="#Arial-BoldMT-36" transform="translate(383.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-2192" transform="translate(439.111328 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(539.111328 0)"/>
+    </g>
+    <!-- ReLU -->
+    <g style="fill: #2d3436" transform="translate(344.349929 236.426511) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-52"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(72.216797 0)"/>
+     <use xlink:href="#Arial-BoldMT-4c" transform="translate(127.832031 0)"/>
+     <use xlink:href="#Arial-BoldMT-55" transform="translate(188.916016 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- Concat -->
+    <g style="fill: #2d3436" transform="translate(665.393277 164.705586) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-43"/>
+     <use xlink:href="#Arial-BoldMT-6f" transform="translate(72.216797 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(133.300781 0)"/>
+     <use xlink:href="#Arial-BoldMT-63" transform="translate(194.384766 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(250 0)"/>
+     <use xlink:href="#Arial-BoldMT-74" transform="translate(305.615234 0)"/>
+    </g>
+    <!-- [8+1=9] -->
+    <g style="fill: #2d3436" transform="translate(664.911168 173.714258) scale(0.085 -0.085)">
+     <defs>
+      <path id="Arial-BoldMT-5b" d="M 456 -1291 
+L 456 4581 
+L 2013 4581 
+L 2013 3891 
+L 1291 3891 
+L 1291 -600 
+L 2013 -600 
+L 2013 -1291 
+L 456 -1291 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-2b" d="M 1466 659 
+L 1466 1850 
+L 266 1850 
+L 266 2672 
+L 1466 2672 
+L 1466 3863 
+L 2266 3863 
+L 2266 2672 
+L 3469 2672 
+L 3469 1850 
+L 2266 1850 
+L 2266 659 
+L 1466 659 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-3d" d="M 266 2550 
+L 266 3356 
+L 3469 3356 
+L 3469 2550 
+L 266 2550 
+z
+M 266 1163 
+L 266 1972 
+L 3469 1972 
+L 3469 1163 
+L 266 1163 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-39" d="M 291 1059 
+L 1141 1153 
+Q 1172 894 1303 769 
+Q 1434 644 1650 644 
+Q 1922 644 2112 894 
+Q 2303 1144 2356 1931 
+Q 2025 1547 1528 1547 
+Q 988 1547 595 1964 
+Q 203 2381 203 3050 
+Q 203 3747 617 4173 
+Q 1031 4600 1672 4600 
+Q 2369 4600 2816 4061 
+Q 3263 3522 3263 2288 
+Q 3263 1031 2797 475 
+Q 2331 -81 1584 -81 
+Q 1047 -81 715 205 
+Q 384 491 291 1059 
+z
+M 2278 2978 
+Q 2278 3403 2083 3637 
+Q 1888 3872 1631 3872 
+Q 1388 3872 1227 3680 
+Q 1066 3488 1066 3050 
+Q 1066 2606 1241 2398 
+Q 1416 2191 1678 2191 
+Q 1931 2191 2104 2391 
+Q 2278 2591 2278 2978 
+z
+" transform="scale(0.015625)"/>
+      <path id="Arial-BoldMT-5d" d="M 1675 4581 
+L 1675 -1291 
+L 119 -1291 
+L 119 -600 
+L 841 -600 
+L 841 3897 
+L 119 3897 
+L 119 4581 
+L 1675 4581 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#Arial-BoldMT-5b"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(33.300781 0)"/>
+     <use xlink:href="#Arial-BoldMT-2b" transform="translate(88.916016 0)"/>
+     <use xlink:href="#Arial-BoldMT-31" transform="translate(147.314453 0)"/>
+     <use xlink:href="#Arial-BoldMT-3d" transform="translate(202.929688 0)"/>
+     <use xlink:href="#Arial-BoldMT-39" transform="translate(261.328125 0)"/>
+     <use xlink:href="#Arial-BoldMT-5d" transform="translate(316.943359 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- Linear 9→8 -->
+    <g style="fill: #2d3436" transform="translate(755.896922 164.73932) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-4c"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(61.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(300.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-39" transform="translate(327.880859 0)"/>
+     <use xlink:href="#Arial-BoldMT-2192" transform="translate(383.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(483.496094 0)"/>
+    </g>
+    <!-- ReLU -->
+    <g style="fill: #2d3436" transform="translate(767.709929 173.717711) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-52"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(72.216797 0)"/>
+     <use xlink:href="#Arial-BoldMT-4c" transform="translate(127.832031 0)"/>
+     <use xlink:href="#Arial-BoldMT-55" transform="translate(188.916016 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- Linear 8→1 -->
+    <g style="fill: #2d3436" transform="translate(861.736922 169.228516) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-4c"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(61.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-6e" transform="translate(88.867188 0)"/>
+     <use xlink:href="#Arial-BoldMT-65" transform="translate(149.951172 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(205.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.181641 0)"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(300.097656 0)"/>
+     <use xlink:href="#Arial-BoldMT-38" transform="translate(327.880859 0)"/>
+     <use xlink:href="#Arial-BoldMT-2192" transform="translate(383.496094 0)"/>
+     <use xlink:href="#Arial-BoldMT-31" transform="translate(483.496094 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- Sigmoid -->
+    <g style="fill: #2d3436" transform="translate(973.724812 164.617398) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-53"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(66.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-67" transform="translate(94.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-6d" transform="translate(155.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-6f" transform="translate(244.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-69" transform="translate(305.566406 0)"/>
+     <use xlink:href="#Arial-BoldMT-64" transform="translate(333.349609 0)"/>
+    </g>
+    <!-- → P(fraud) -->
+    <g style="fill: #2d3436" transform="translate(968.767586 173.831664) scale(0.085 -0.085)">
+     <use xlink:href="#Arial-BoldMT-2192"/>
+     <use xlink:href="#Arial-BoldMT-20" transform="translate(100 0)"/>
+     <use xlink:href="#Arial-BoldMT-50" transform="translate(127.783203 0)"/>
+     <use xlink:href="#Arial-BoldMT-28" transform="translate(194.482422 0)"/>
+     <use xlink:href="#Arial-BoldMT-66" transform="translate(227.783203 0)"/>
+     <use xlink:href="#Arial-BoldMT-72" transform="translate(261.083984 0)"/>
+     <use xlink:href="#Arial-BoldMT-61" transform="translate(300 0)"/>
+     <use xlink:href="#Arial-BoldMT-75" transform="translate(355.615234 0)"/>
+     <use xlink:href="#Arial-BoldMT-64" transform="translate(416.699219 0)"/>
+     <use xlink:href="#Arial-BoldMT-29" transform="translate(477.783203 0)"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pf4e1ab6c4f">
+   <rect x="7.2" y="24.505156" width="1058.4" height="285.04"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/scripts/run_conceptual_figures.py
+++ b/scripts/run_conceptual_figures.py
@@ -34,6 +34,7 @@ from src.evaluation.plots import (
     plot_hilbert_space,
     plot_parameter_breakdown,
     plot_pca_scree,
+    plot_phnn_architecture,
     plot_shnn_architecture,
     plot_smote_illustration,
 )
@@ -120,6 +121,9 @@ def main() -> None:
 
     # ── 4. SHNN architecture diagram ─────────────────────────────────────
     plot_shnn_architecture(out / "shnn_architecture.png")
+
+    # ── 4b. PHNN architecture diagram ────────────────────────────────────
+    plot_phnn_architecture(out / "phnn_architecture.svg")
 
     # ── 5. PCA scree plot ─────────────────────────────────────────────────
     # Apply RobustScaler + MinMaxScaler first (matching the actual pipeline),

--- a/src/evaluation/plots.py
+++ b/src/evaluation/plots.py
@@ -636,6 +636,123 @@ def plot_shnn_architecture(save_path: Path) -> None:
     _save(fig, save_path)
 
 
+def plot_phnn_architecture(save_path: Path) -> None:
+    """Flow diagram of the PHNN parallel hybrid pipeline."""
+    fig, ax = plt.subplots(figsize=(15, 4.5))
+    ax.set_xlim(0, 15.5)
+    ax.set_ylim(0, 1)
+    ax.axis("off")
+
+    box_w, box_h = 1.3, 0.36
+    y_q = 0.72
+    y_m = 0.50
+    y_c = 0.28
+    gray = "#DFE6E9"
+    purple = "#D8CCF5"
+    q_color = COLORS["shnn"]
+    arrow_color = "#636E72"
+
+    def draw_box(cx, cy, label, facecolor, edgecolor, bw=None):
+        bw = bw or box_w
+        fancy = plt.matplotlib.patches.FancyBboxPatch(
+            (cx - bw / 2, cy - box_h / 2), bw, box_h,
+            boxstyle="round,pad=0.04",
+            facecolor=facecolor, edgecolor=edgecolor, linewidth=1.8, zorder=3,
+        )
+        ax.add_patch(fancy)
+        ax.text(cx, cy, label, ha="center", va="center",
+                fontsize=8.5, fontweight="bold", zorder=4, color="#2D3436")
+
+    def harrow(x1, y, x2):
+        ax.annotate("", xy=(x2, y), xytext=(x1, y),
+                    arrowprops={"arrowstyle": "->", "color": arrow_color, "lw": 1.5},
+                    zorder=2)
+
+    def hline(x1, y, x2):
+        ax.plot([x1, x2], [y, y], color=arrow_color, lw=1.5, zorder=2)
+
+    def vline(x, y1, y2):
+        ax.plot([x, x], [y1, y2], color=arrow_color, lw=1.5, zorder=2)
+
+    # ── Input ─────────────────────────────────────────────────────────────
+    input_cx = 0.8
+    draw_box(input_cx, y_m, "Input\n(8 features)", gray, "black")
+
+    # ── T-junction split ──────────────────────────────────────────────────
+    split_x = 1.58
+    hline(input_cx + box_w / 2 + 0.03, y_m, split_x)
+    vline(split_x, y_c, y_q)
+
+    # ── Quantum branch ─────────────────────────────────────────────────────
+    q_blocks = [
+        (2.55,  "Linear 8→8\n(vqc_proj)",             gray,   "black",  box_w),
+        (4.25,  "PiSigmoid\n×π",                       gray,   "black",  box_w),
+        (6.25,  "VQC\n8 qubits · 2 layers\n48 params", purple, q_color,  1.6),
+        (8.15,  "<Z0>\nMeasurement",                   purple, q_color,  box_w),
+    ]
+    harrow(split_x, y_q, q_blocks[0][0] - q_blocks[0][4] / 2 - 0.03)
+    for i, (cx, label, fc, ec, bw) in enumerate(q_blocks):
+        draw_box(cx, y_q, label, fc, ec, bw)
+        if i > 0:
+            prev_cx, prev_bw = q_blocks[i - 1][0], q_blocks[i - 1][4]
+            harrow(prev_cx + prev_bw / 2 + 0.03, y_q, cx - bw / 2 - 0.03)
+
+    # ── Classical branch ───────────────────────────────────────────────────
+    c_blocks = [
+        (3.1,  "Linear 8→16\nReLU", gray, "black", box_w),
+        (5.1,  "Linear 16→8\nReLU", gray, "black", box_w),
+    ]
+    harrow(split_x, y_c, c_blocks[0][0] - box_w / 2 - 0.03)
+    for i, (cx, label, fc, ec, bw) in enumerate(c_blocks):
+        draw_box(cx, y_c, label, fc, ec, bw)
+        if i > 0:
+            prev_cx = c_blocks[i - 1][0]
+            harrow(prev_cx + box_w / 2 + 0.03, y_c, cx - bw / 2 - 0.03)
+
+    # ── Reverse-T merge ────────────────────────────────────────────────────
+    merge_x = 9.05
+    last_q_cx, last_q_bw = q_blocks[-1][0], q_blocks[-1][4]
+    last_c_cx = c_blocks[-1][0]
+    hline(last_q_cx + last_q_bw / 2 + 0.03, y_q, merge_x)
+    hline(last_c_cx + box_w / 2 + 0.03, y_c, merge_x)
+    vline(merge_x, y_c, y_q)
+
+    # ── Concat and head ────────────────────────────────────────────────────
+    concat_cx = 9.85
+    harrow(merge_x, y_m, concat_cx - box_w / 2 - 0.03)
+    draw_box(concat_cx, y_m, "Concat\n[8+1=9]", gray, "black")
+
+    head_blocks = [
+        (11.3,  "Linear 9→8\nReLU",    gray, "black"),
+        (12.85, "Linear 8→1",          gray, "black"),
+        (14.4,  "Sigmoid\n→ P(fraud)", gray, "black"),
+    ]
+    harrow(concat_cx + box_w / 2 + 0.03, y_m, head_blocks[0][0] - box_w / 2 - 0.03)
+    for i, (cx, label, fc, ec) in enumerate(head_blocks):
+        draw_box(cx, y_m, label, fc, ec)
+        if i > 0:
+            harrow(head_blocks[i - 1][0] + box_w / 2 + 0.03, y_m, cx - box_w / 2 - 0.03)
+
+    # ── Quantum module bracket ─────────────────────────────────────────────
+    vqc_cx, vqc_bw = q_blocks[2][0], q_blocks[2][4]
+    z0_cx = q_blocks[3][0]
+    q_start = vqc_cx - vqc_bw / 2 - 0.05
+    q_end = z0_cx + box_w / 2 + 0.05
+    bracket_y = y_q - box_h / 2 - 0.10
+    ax.annotate(
+        "", xy=(q_end, bracket_y), xytext=(q_start, bracket_y),
+        arrowprops={"arrowstyle": "<->", "color": COLORS["parallel"], "lw": 1.5},
+    )
+    ax.text((q_start + q_end) / 2, bracket_y - 0.07,
+            "Quantum module (PennyLane · lightning.qubit)",
+            ha="center", fontsize=8.5, color=COLORS["parallel"], style="italic")
+
+    ax.set_title("PHNN — Parallel Hybrid Neural Network Architecture",
+                 fontsize=13, fontweight="bold", pad=8)
+    fig.tight_layout()
+    _save(fig, save_path)
+
+
 def plot_pca_scree(X: np.ndarray, n_highlight: int, save_path: Path) -> None:
     """Scree plot of cumulative explained variance, vertical line at n_highlight."""
     from sklearn.decomposition import PCA

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -25,6 +25,7 @@ from src.evaluation.plots import (
     plot_parameter_breakdown,
     plot_parameter_efficiency,
     plot_pca_scree,
+    plot_phnn_architecture,
     plot_shnn_architecture,
     plot_smote_illustration,
     plot_statistical_heatmap,
@@ -168,6 +169,12 @@ def test_plot_hilbert_space(tmp_path):
 def test_plot_shnn_architecture(tmp_path):
     out = tmp_path / "shnn_architecture.png"
     plot_shnn_architecture(save_path=out)
+    _assert_file(out)
+
+
+def test_plot_phnn_architecture(tmp_path):
+    out = tmp_path / "phnn_architecture.svg"
+    plot_phnn_architecture(save_path=out)
     _assert_file(out)
 
 


### PR DESCRIPTION
## Summary

- Adds `plot_phnn_architecture()` to `src/evaluation/plots.py` with a parallel-split layout (T-junction split → two branches → reverse-T merge → head)
- Quantum branch: `Linear 8→8 (vqc_proj)` → `PiSigmoid ×π` → `VQC 8q·2L 48 params` → `<Z0> Measurement`; blue bracket labelled "Quantum module (PennyLane · lightning.qubit)"
- Classical branch: `Linear 8→16 ReLU` → `Linear 16→8 ReLU`
- Head: `Concat [8+1=9]` → `Linear 9→8` → `Linear 8→1` → `Sigmoid`
- Calls added to `scripts/run_conceptual_figures.py`; smoke test added to `tests/test_plots.py` (62/62 passing)
- `results/figures/phnn_architecture.svg` committed

## Test plan

- [x] `pixi run test` — 62/62 passed
- [x] SVG generated locally at `results/figures/phnn_architecture.svg` (66 KB)
- [ ] Visual inspection of SVG in browser / Word before merge

Closes #130